### PR TITLE
Fix annotation processor & handler

### DIFF
--- a/src/main/java/gg/nextforge/protocol/listener/AnnotationProcessor.java
+++ b/src/main/java/gg/nextforge/protocol/listener/AnnotationProcessor.java
@@ -11,11 +11,23 @@ import java.lang.reflect.Method;
 import java.util.*;
 
 /**
- * Processes <code>@PacketHandler</code> annotations to automatically register methods as packet listeners.
- *
- * This class scans objects for methods annotated with <code>@PacketHandler</code> and registers them
- * as packet listeners using reflection. It supports validation of method signatures,
- * parsing packet types, and applying JavaScript filters for additional control.
+ * Processes {@link PacketAdapter.PacketHandler} annotations to automatically
+ * register methods as packet listeners.<br>
+ * <br>
+ * Example usage:
+ * <pre>{@code
+ * public class MyListener {
+ *     @PacketAdapter.PacketHandler(types = {"PLAY_SERVER_CHAT"}, priority = ListenerPriority.HIGH)
+ *     public void onChat(Player player, PacketContainer packet) {
+ *         // handle packet
+ *     }
+ * }
+ * }</pre>
+ * <br>
+ * This processor scans objects for methods annotated with
+ * {@code @PacketHandler} and registers them using reflection. It validates
+ * method signatures, parses packet types and applies optional JavaScript
+ * filters defined in the annotation.
  *
  * @see gg.nextforge.protocol.listener.PacketAdapter.PacketHandler
  */
@@ -94,7 +106,12 @@ public class AnnotationProcessor {
     public void unregisterHandlers(Object handler) {
         List<PacketListener> listeners = registeredListeners.remove(handler);
         if (listeners != null) {
-            listeners.forEach(protocol::unregisterListener);
+            for (PacketListener listener : listeners) {
+                protocol.unregisterListener(listener);
+                if (listener instanceof MethodPacketListener mpl) {
+                    mpl.close();
+                }
+            }
         }
     }
 
@@ -107,6 +124,7 @@ public class AnnotationProcessor {
         private final boolean sending; // Whether the listener handles sending packets
         private final boolean receiving; // Whether the listener handles receiving packets
         private final String filter; // Optional JavaScript filter for packet handling
+        private final String filterName; // Compiled filter identifier
 
         /**
          * Constructs a MethodPacketListener instance.
@@ -127,6 +145,14 @@ public class AnnotationProcessor {
             this.sending = annotation.sending();
             this.receiving = annotation.receiving();
             this.filter = annotation.filter();
+
+            if (filter != null && !filter.isEmpty()) {
+                this.filterName = "handler_" + method.getName() + "_" + System.nanoTime();
+                var engine = NextForgePlugin.getInstance().getProtocolManager().getScriptEngine();
+                engine.compileFilter(filterName, filter);
+            } else {
+                this.filterName = null;
+            }
 
             method.setAccessible(true); // Allows access to private methods
         }
@@ -169,16 +195,11 @@ public class AnnotationProcessor {
          */
         private boolean invokeMethod(Player player, PacketContainer packet) {
             try {
-                // Apply JavaScript filter if specified
-                if (filter != null && !filter.isEmpty()) {
-                    var scriptEngine = NextForgePlugin.getInstance().getProtocolManager().getScriptEngine();
-                    String tempName = "temp_" + System.nanoTime();
-                    scriptEngine.compileFilter(tempName, filter);
-                    boolean filterResult = scriptEngine.executeFilter(tempName, player, packet);
-                    scriptEngine.removeFilter(tempName);
-
-                    if (!filterResult) {
-                        return false; // Filter rejected the packet
+                // Apply precompiled JavaScript filter if specified
+                if (filterName != null) {
+                    var engine = NextForgePlugin.getInstance().getProtocolManager().getScriptEngine();
+                    if (!engine.executeFilter(filterName, player, packet)) {
+                        return false;
                     }
                 }
 
@@ -199,5 +220,14 @@ public class AnnotationProcessor {
                 return true;
             }
         }
-    }
-}
+
+        /**
+         * Removes any compiled script resources.
+         */
+        public void close() {
+            if (filterName != null) {
+                var engine = NextForgePlugin.getInstance().getProtocolManager().getScriptEngine();
+                engine.removeFilter(filterName);
+            }
+        }
+    }}

--- a/src/main/java/gg/nextforge/protocol/listener/PacketAdapter.java
+++ b/src/main/java/gg/nextforge/protocol/listener/PacketAdapter.java
@@ -4,18 +4,21 @@ import gg.nextforge.protocol.packet.PacketContainer;
 import gg.nextforge.protocol.packet.PacketType;
 import org.bukkit.plugin.Plugin;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Convenience adapter for packet listeners.
- * <p>
- * This class simplifies the implementation of packet listeners by allowing developers
- * to override only the methods they need. It provides multiple constructors for different
- * configurations and a builder for creating adapters with custom behavior.
+ * Convenience adapter for packet listeners.<br>
+ * <br>
+ * Developers can extend this class to quickly implement custom packet logic or
+ * annotate methods with {@link PacketHandler} for automatic registration via
+ * {@link AnnotationProcessor}. A small builder utility is also provided for
+ * simple lambda based listeners.
  */
 public abstract class PacketAdapter extends PacketListener {
 
@@ -65,17 +68,53 @@ public abstract class PacketAdapter extends PacketListener {
     }
 
     /**
-     * Functional interface for handling packets.
-     * Allows the use of lambda expressions for defining packet behavior.
+     * Annotation used to mark methods as packet handlers that should be
+     * automatically registered by {@link AnnotationProcessor}.<br>
+     * <br>
+     * Example usage:
+     * <pre>{@code
+     * @PacketAdapter.PacketHandler(types = {"PLAY_CLIENT_CHAT"})
+     * public void onChat(Player player, PacketContainer packet) {
+     *     // handle packet
+     * }
+     * }</pre>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface PacketHandler {
+        /** Listener priority. */
+        ListenerPriority priority() default ListenerPriority.NORMAL;
+
+        /**
+         * Whether to listen for outgoing packets.
+         */
+        boolean sending() default true;
+
+        /**
+         * Whether to listen for incoming packets.
+         */
+        boolean receiving() default true;
+
+        /**
+         * Optional packet types to filter. If empty, all types will be passed.
+         */
+        String[] types() default {};
+
+        /**
+         * Optional JavaScript filter string executed before the handler.
+         */
+        String filter() default "";
+    }
+
+    /**
+     * Functional interface for lambda based packet handlers used by the
+     * {@link Builder}. It mirrors the signature expected by
+     * {@link PacketListener} methods.
      */
     @FunctionalInterface
-    public interface PacketHandler {
+    public interface PacketConsumer {
         /**
-         * Handles a packet.
-         *
-         * @param player The player associated with the packet.
-         * @param packet The packet being handled.
-         * @return true to allow the packet, false to cancel it.
+         * Handle a packet for the given player.
          */
         boolean handle(org.bukkit.entity.Player player, PacketContainer packet);
     }
@@ -88,8 +127,8 @@ public abstract class PacketAdapter extends PacketListener {
         private final Set<PacketType> sendingTypes = new HashSet<>();
         private final Set<PacketType> receivingTypes = new HashSet<>();
         private ListenerPriority priority = ListenerPriority.NORMAL;
-        private PacketHandler sendingHandler = null;
-        private PacketHandler receivingHandler = null;
+        private PacketConsumer sendingHandler = null;
+        private PacketConsumer receivingHandler = null;
 
         /**
          * Constructs a Builder instance.
@@ -139,7 +178,7 @@ public abstract class PacketAdapter extends PacketListener {
          * @param handler The PacketHandler instance.
          * @return The current Builder instance for chaining.
          */
-        public Builder onSending(PacketHandler handler) {
+        public Builder onSending(PacketConsumer handler) {
             this.sendingHandler = handler;
             return this;
         }
@@ -150,7 +189,7 @@ public abstract class PacketAdapter extends PacketListener {
          * @param handler The PacketHandler instance.
          * @return The current Builder instance for chaining.
          */
-        public Builder onReceiving(PacketHandler handler) {
+        public Builder onReceiving(PacketConsumer handler) {
             this.receivingHandler = handler;
             return this;
         }


### PR DESCRIPTION
## Summary
- add `PacketAdapter.PacketHandler` annotation and `PacketConsumer` interface
- update `AnnotationProcessor` to use compiled filters and clean up
- document example usage for annotation processor
- adjust builder to use new functional interface

## Testing
- `./gradlew test` *(fails: package lombok does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686d47c8c12c832cb0f27062e5a74db0