### PR TITLE
Add auto updater and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+      - name: Run tests
+        run: ./gradlew test
+      - name: Build shadowJar
+        run: ./gradlew shadowJar
+      - name: Extract version
+        id: vars
+        run: |
+          echo "version=$(grep -m1 '^version' build.gradle | sed -E "s/version\s*=\s*['\"]([^'\"]+)['\"]/\1/")" >> $GITHUB_OUTPUT
+      - name: Create Release
+        id: create
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.vars.outputs.version }}
+          release_name: ${{ steps.vars.outputs.version }}
+          draft: false
+          prerelease: false
+      - name: Upload JAR
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create.outputs.upload_url }}
+          asset_path: $(ls build/libs/*.jar | head -n 1)
+          asset_name: nextforge-${{ steps.vars.outputs.version }}.jar
+          asset_content_type: application/java-archive

--- a/src/main/java/gg/nextforge/updater/CoreAutoUpdater.java
+++ b/src/main/java/gg/nextforge/updater/CoreAutoUpdater.java
@@ -1,7 +1,162 @@
 package gg.nextforge.updater;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Provides utilities for checking for updates and downloading the latest JAR
+ * from GitHub releases.
+ */
 public class CoreAutoUpdater {
 
+    private static final Logger LOGGER = Logger.getLogger(CoreAutoUpdater.class.getName());
+    private static final String OWNER = "nextforge";
+    private static final String REPO = "protocol";
+    private static final String RELEASE_API = "https://api.github.com/repos/%s/%s/releases/latest";
 
+    private final Gson gson = new Gson();
+    private final File downloadDir;
+    private final String currentVersion;
 
+    /**
+     * Creates an updater using the version from build.gradle.
+     *
+     * @param projectDir  the project directory containing build.gradle
+     * @param downloadDir the directory to download new JARs to
+     */
+    public CoreAutoUpdater(File projectDir, File downloadDir) {
+        this.currentVersion = readVersionFromBuild(new File(projectDir, "build.gradle"));
+        this.downloadDir = downloadDir;
+    }
+
+    /**
+     * Creates an updater with a provided current version.
+     *
+     * @param currentVersion the current version string
+     * @param downloadDir    the directory to download new JARs to
+     */
+    public CoreAutoUpdater(String currentVersion, File downloadDir) {
+        this.currentVersion = currentVersion;
+        this.downloadDir = downloadDir;
+    }
+
+    private String readVersionFromBuild(File buildFile) {
+        Pattern p = Pattern.compile("version\\s*=\\s*['\"]([^'\"]+)['\"]");
+        try (BufferedReader reader = new BufferedReader(new FileReader(buildFile))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Matcher m = p.matcher(line.trim());
+                if (m.find()) {
+                    return m.group(1);
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to read version from build file", e);
+        }
+        return "";
+    }
+
+    private HttpURLConnection openConnection(String url) throws IOException {
+        URL u = new URL(url);
+        HttpURLConnection conn = (HttpURLConnection) u.openConnection();
+        conn.setRequestProperty("Accept", "application/vnd.github+json");
+        String token = System.getenv("GITHUB_TOKEN");
+        if (token != null && !token.isBlank()) {
+            conn.setRequestProperty("Authorization", "token " + token);
+        }
+        return conn;
+    }
+
+    private JsonObject getLatestRelease() throws IOException {
+        HttpURLConnection conn = openConnection(String.format(RELEASE_API, OWNER, REPO));
+        try (InputStream in = conn.getInputStream();
+             InputStreamReader reader = new InputStreamReader(in)) {
+            return gson.fromJson(reader, JsonObject.class);
+        }
+    }
+
+    /**
+     * Fetches the tag name of the latest release on GitHub.
+     *
+     * @return the latest release tag
+     * @throws IOException if the request fails
+     */
+    public String fetchLatestVersion() throws IOException {
+        JsonObject release = getLatestRelease();
+        return release.get("tag_name").getAsString();
+    }
+
+    /**
+     * Determines whether the current version matches the latest release.
+     *
+     * @return true if the current version is up-to-date
+     * @throws IOException if the GitHub request fails
+     */
+    public boolean isLatestVersion() throws IOException {
+        String latest = fetchLatestVersion();
+        return currentVersion != null && currentVersion.equalsIgnoreCase(latest);
+    }
+
+    /**
+     * Downloads the latest release JAR if a newer version is available.
+     *
+     * @param downloadIfNew if true, download only when a newer version exists
+     * @return the downloaded file, or null if no download occurred
+     * @throws IOException if downloading fails
+     */
+    public File downloadLatestJar(boolean downloadIfNew) throws IOException {
+        JsonObject release = getLatestRelease();
+        String latest = release.get("tag_name").getAsString();
+        if (downloadIfNew && latest.equalsIgnoreCase(currentVersion)) {
+            LOGGER.info("Already on the latest version: " + latest);
+            return null;
+        }
+
+        JsonArray assets = release.getAsJsonArray("assets");
+        for (JsonElement el : assets) {
+            JsonObject asset = el.getAsJsonObject();
+            String name = asset.get("name").getAsString();
+            if (name.endsWith(".jar")) {
+                String url = asset.get("browser_download_url").getAsString();
+                return downloadFile(url, name);
+            }
+        }
+        LOGGER.warning("No JAR asset found in the latest release");
+        return null;
+    }
+
+    private File downloadFile(String url, String name) throws IOException {
+        if (!downloadDir.exists()) {
+            Files.createDirectories(downloadDir.toPath());
+        }
+        File out = new File(downloadDir, name);
+        LOGGER.info("Downloading " + url + " to " + out.getAbsolutePath());
+        HttpURLConnection conn = openConnection(url);
+        try (InputStream in = conn.getInputStream();
+             FileOutputStream fos = new FileOutputStream(out)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                fos.write(buffer, 0, read);
+            }
+        }
+        return out;
+    }
 }


### PR DESCRIPTION
## Summary
- implement `CoreAutoUpdater` for checking GitHub releases and downloading latest JARs
- add GitHub Actions workflow for building and creating releases

## Testing
- `./gradlew test` *(fails: cannot find required Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_686d572c8bd0832c8599a74825362919