### PR TITLE
Implement basic hologram API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation "org.mozilla:rhino:1.7.14"
     implementation "com.google.code.gson:gson:2.10.1"
     implementation "org.bstats:bstats-bukkit:3.0.2"
+    testImplementation "org.junit.jupiter:junit-jupiter:5.9.3"
+    testImplementation "org.mockito:mockito-core:5.5.0"
 }
 
 subprojects {
@@ -70,6 +72,10 @@ java {
 tasks {
     compileJava {
         options.encoding = "UTF-8"
+    }
+
+    test {
+        useJUnitPlatform()
     }
 
     // Haupt-Versionserweiterung für plugin.yml

--- a/src/main/java/gg/nextforge/NextCorePlugin.java
+++ b/src/main/java/gg/nextforge/NextCorePlugin.java
@@ -48,6 +48,7 @@ public class NextCorePlugin extends NextForgePlugin {
 
         new NextCoreCommand(this);
         new NPCCommand(this, getNpcManager());
+        new gg.nextforge.textblockitemdisplay.HologramCommand(this, getHologramManager());
 
         ConsoleHeader.send(this);
 

--- a/src/main/java/gg/nextforge/plugin/NextForgePlugin.java
+++ b/src/main/java/gg/nextforge/plugin/NextForgePlugin.java
@@ -7,6 +7,7 @@ import gg.nextforge.npc.NPCManager;
 import gg.nextforge.protocol.ProtocolManager;
 import gg.nextforge.scheduler.CoreScheduler;
 import gg.nextforge.text.TextManager;
+import gg.nextforge.textblockitemdisplay.HologramManager;
 import lombok.Getter;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.plugin.Plugin;
@@ -25,6 +26,7 @@ public abstract class NextForgePlugin extends JavaPlugin {
     CommandManager commandManager;
     TextManager textManager;
     NPCManager npcManager;
+    HologramManager hologramManager;
     ProtocolManager protocolManager;
     Metrics metrics;
 
@@ -60,6 +62,7 @@ public abstract class NextForgePlugin extends JavaPlugin {
         this.commandManager = new CommandManager(this);
         this.textManager = new TextManager(this);
         this.npcManager = new NPCManager(this);
+        this.hologramManager = new HologramManager();
         this.protocolManager = new ProtocolManager(this);
 
         boolean isReload = getServer().getPluginManager().isPluginEnabled("NextForge");

--- a/src/main/java/gg/nextforge/textblockitemdisplay/BlockHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/BlockHologram.java
@@ -1,0 +1,20 @@
+package gg.nextforge.textblockitemdisplay;
+
+import org.bukkit.Material;
+
+/**
+ * Represents a hologram displaying a block.
+ */
+public interface BlockHologram extends Hologram {
+    /**
+     * @return block type displayed by this hologram.
+     */
+    Material getBlockType();
+
+    /**
+     * Sets block type.
+     *
+     * @param material material to display
+     */
+    void setBlockType(Material material);
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/Hologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/Hologram.java
@@ -1,0 +1,42 @@
+package gg.nextforge.textblockitemdisplay;
+
+import org.bukkit.Location;
+
+/**
+ * Base interface for all hologram types.
+ */
+public interface Hologram {
+    /**
+     * @return name of the hologram.
+     */
+    String getName();
+
+    /**
+     * Get the current location of the hologram.
+     *
+     * @return hologram location
+     */
+    Location getLocation();
+
+    /**
+     * Sets the location of this hologram.
+     *
+     * @param location new location
+     */
+    void setLocation(Location location);
+
+    /**
+     * Spawns the hologram.
+     */
+    void spawn();
+
+    /**
+     * Removes the hologram from the world.
+     */
+    void despawn();
+
+    /**
+     * @return whether the hologram is currently spawned
+     */
+    boolean isSpawned();
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/HologramCommand.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/HologramCommand.java
@@ -1,0 +1,150 @@
+package gg.nextforge.textblockitemdisplay;
+
+import gg.nextforge.NextCorePlugin;
+import gg.nextforge.command.CommandContext;
+import gg.nextforge.command.CommandManager;
+import gg.nextforge.text.TextManager;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Command handling for hologram operations.
+ */
+public class HologramCommand {
+    private final NextCorePlugin plugin;
+    private final HologramManager manager;
+    private final TextManager text;
+
+    public HologramCommand(NextCorePlugin plugin, HologramManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+        this.text = plugin.getTextManager();
+        register();
+    }
+
+    private void register() {
+        CommandManager cm = plugin.getCommandManager();
+        cm.command("hologram")
+                .permission("nextforge.command.hologram")
+                .description("Manage holograms")
+                .executor(this::handleHelp)
+                .subcommand("help", this::handleHelp)
+                .subcommand("list", this::handleList)
+                .subcommand("nearby", this::handleNearby)
+                .subcommand("create", this::handleCreate)
+                .subcommand("remove", this::handleRemove)
+                .subcommand("copy", this::handleCopy)
+                .subcommand("info", this::handleInfo)
+                .register();
+    }
+
+    private void handleHelp(CommandContext ctx) {
+        text.send(ctx.sender(), "<gray>/hologram list</gray> - list holograms");
+        text.send(ctx.sender(), "<gray>/hologram create (type) (name)</gray>");
+    }
+
+    private void handleList(CommandContext ctx) {
+        for (Hologram h : manager.getHolograms()) {
+            text.send(ctx.sender(), " - " + h.getName());
+        }
+    }
+
+    private void handleNearby(CommandContext ctx) {
+        if (!(ctx.sender() instanceof Player player)) {
+            text.send(ctx.sender(), "Only players");
+            return;
+        }
+        double range = 10;
+        if (ctx.args().length > 0) {
+            range = Double.parseDouble(ctx.args()[0]);
+        }
+        Location loc = player.getLocation();
+        for (Hologram h : manager.getHolograms()) {
+            if (h.getLocation().getWorld().equals(loc.getWorld()) &&
+                    h.getLocation().distance(loc) <= range) {
+                text.send(player, " - " + h.getName());
+            }
+        }
+    }
+
+    private void handleCreate(CommandContext ctx) {
+        if (!(ctx.sender() instanceof Player player)) {
+            text.send(ctx.sender(), "Only players");
+            return;
+        }
+        if (ctx.args().length < 2) {
+            text.send(ctx.sender(), "Usage: /hologram create (type) (name)");
+            return;
+        }
+        String type = ctx.args()[0].toLowerCase();
+        String name = ctx.args()[1];
+        Location loc = player.getLocation();
+        switch (type) {
+            case "text" -> manager.createTextHologram(name, loc);
+            case "item" -> manager.createItemHologram(name, loc, player.getInventory().getItemInMainHand());
+            case "block" -> manager.createBlockHologram(name, loc, Material.STONE);
+            default -> {
+                text.send(ctx.sender(), "Unknown type");
+                return;
+            }
+        }
+        text.send(ctx.sender(), "Created hologram " + name);
+    }
+
+    private void handleRemove(CommandContext ctx) {
+        if (ctx.args().length < 1) {
+            text.send(ctx.sender(), "Usage: /hologram remove (name)");
+            return;
+        }
+        manager.remove(ctx.args()[0]);
+        text.send(ctx.sender(), "Removed hologram");
+    }
+
+    private void handleCopy(CommandContext ctx) {
+        if (ctx.args().length < 2) {
+            text.send(ctx.sender(), "Usage: /hologram copy (src) (dest)");
+            return;
+        }
+        Hologram src = manager.get(ctx.args()[0]);
+        if (src == null) {
+            text.send(ctx.sender(), "Not found");
+            return;
+        }
+        Location loc = src.getLocation();
+        if (src instanceof TextHologram th) {
+            TextHologram nh = manager.createTextHologram(ctx.args()[1], loc);
+            th.getLines().forEach(nh::addLine);
+        } else if (src instanceof ItemHologram ih) {
+            manager.createItemHologram(ctx.args()[1], loc, ih.getItem());
+        } else if (src instanceof BlockHologram bh) {
+            manager.createBlockHologram(ctx.args()[1], loc, bh.getBlockType());
+        }
+        text.send(ctx.sender(), "Copied hologram");
+    }
+
+    private void handleInfo(CommandContext ctx) {
+        if (ctx.args().length < 1) {
+            text.send(ctx.sender(), "Usage: /hologram info (name)");
+            return;
+        }
+        Hologram h = manager.get(ctx.args()[0]);
+        if (h == null) {
+            text.send(ctx.sender(), "Not found");
+            return;
+        }
+        text.send(ctx.sender(), "Name: " + h.getName());
+        text.send(ctx.sender(), "Location: " + h.getLocation().toVector());
+        if (h instanceof TextHologram th) {
+            text.send(ctx.sender(), "Lines: " + th.getLines().size());
+        }
+        if (h instanceof ItemHologram ih) {
+            ItemStack item = ih.getItem();
+            text.send(ctx.sender(), "Item: " + item.getType());
+        }
+        if (h instanceof BlockHologram bh) {
+            text.send(ctx.sender(), "Block: " + bh.getBlockType());
+        }
+    }
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/HologramCommand.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/HologramCommand.java
@@ -58,7 +58,12 @@ public class HologramCommand {
         }
         double range = 10;
         if (ctx.args().length > 0) {
-            range = Double.parseDouble(ctx.args()[0]);
+            try {
+                range = Double.parseDouble(ctx.args()[0]);
+            } catch (NumberFormatException e) {
+                text.send(ctx.sender(), "Invalid range. Please provide a valid number.");
+                return;
+            }
         }
         Location loc = player.getLocation();
         for (Hologram h : manager.getHolograms()) {

--- a/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
@@ -73,7 +73,10 @@ public class HologramManager {
     }
 
     /**
-     * Get a hologram by name.
+     * Retrieves a hologram by its name.
+     *
+     * @param name the name of the hologram to retrieve
+     * @return the hologram associated with the given name, or {@code null} if no such hologram exists
      */
     public Hologram get(String name) {
         return holograms.get(name.toLowerCase());

--- a/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
@@ -60,7 +60,10 @@ public class HologramManager {
     }
 
     /**
-     * Remove a hologram by name.
+     * Removes a hologram by name.
+     *
+     * @param name the name of the hologram to remove
+     *             If no hologram exists with the given name, no action is taken.
      */
     public void remove(String name) {
         Hologram h = holograms.remove(name.toLowerCase());

--- a/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
@@ -33,6 +33,11 @@ public class HologramManager {
 
     /**
      * Creates an item hologram.
+     *
+     * @param name     hologram name
+     * @param location spawn location
+     * @param item     item to display
+     * @return created hologram
      */
     public ItemHologram createItemHologram(String name, Location location, ItemStack item) {
         ItemHologram holo = new SimpleItemHologram(name, location, item);

--- a/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
@@ -47,6 +47,11 @@ public class HologramManager {
 
     /**
      * Creates a block hologram.
+     *
+     * @param name     hologram name
+     * @param location spawn location
+     * @param material block material
+     * @return created hologram
      */
     public BlockHologram createBlockHologram(String name, Location location, Material material) {
         BlockHologram holo = new SimpleBlockHologram(name, location, material);

--- a/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/HologramManager.java
@@ -1,0 +1,75 @@
+package gg.nextforge.textblockitemdisplay;
+
+import gg.nextforge.textblockitemdisplay.impl.SimpleBlockHologram;
+import gg.nextforge.textblockitemdisplay.impl.SimpleItemHologram;
+import gg.nextforge.textblockitemdisplay.impl.SimpleTextHologram;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manager responsible for creating and storing holograms.
+ */
+public class HologramManager {
+    private final Map<String, Hologram> holograms = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a text hologram.
+     *
+     * @param name     hologram name
+     * @param location spawn location
+     * @return created hologram
+     */
+    public TextHologram createTextHologram(String name, Location location) {
+        TextHologram holo = new SimpleTextHologram(name, location);
+        holograms.put(name.toLowerCase(), holo);
+        return holo;
+    }
+
+    /**
+     * Creates an item hologram.
+     */
+    public ItemHologram createItemHologram(String name, Location location, ItemStack item) {
+        ItemHologram holo = new SimpleItemHologram(name, location, item);
+        holograms.put(name.toLowerCase(), holo);
+        return holo;
+    }
+
+    /**
+     * Creates a block hologram.
+     */
+    public BlockHologram createBlockHologram(String name, Location location, Material material) {
+        BlockHologram holo = new SimpleBlockHologram(name, location, material);
+        holograms.put(name.toLowerCase(), holo);
+        return holo;
+    }
+
+    /**
+     * Remove a hologram by name.
+     */
+    public void remove(String name) {
+        Hologram h = holograms.remove(name.toLowerCase());
+        if (h != null) {
+            h.despawn();
+        }
+    }
+
+    /**
+     * Get a hologram by name.
+     */
+    public Hologram get(String name) {
+        return holograms.get(name.toLowerCase());
+    }
+
+    /**
+     * @return list of all holograms.
+     */
+    public List<Hologram> getHolograms() {
+        return new ArrayList<>(holograms.values());
+    }
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/ItemHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/ItemHologram.java
@@ -1,0 +1,20 @@
+package gg.nextforge.textblockitemdisplay;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Represents a hologram displaying an item.
+ */
+public interface ItemHologram extends Hologram {
+    /**
+     * @return item displayed by the hologram.
+     */
+    ItemStack getItem();
+
+    /**
+     * Sets the item to display.
+     *
+     * @param item new item
+     */
+    void setItem(ItemStack item);
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/TextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/TextHologram.java
@@ -1,0 +1,35 @@
+package gg.nextforge.textblockitemdisplay;
+
+import java.util.List;
+
+/**
+ * Represents a hologram consisting of text lines.
+ */
+public interface TextHologram extends Hologram {
+    /**
+     * @return mutable list of lines of text.
+     */
+    List<String> getLines();
+
+    /**
+     * Sets a specific line.
+     *
+     * @param index line index
+     * @param text  new text
+     */
+    void setLine(int index, String text);
+
+    /**
+     * Adds a line to the end.
+     *
+     * @param text line to add
+     */
+    void addLine(String text);
+
+    /**
+     * Removes a line by index.
+     *
+     * @param index index of line
+     */
+    void removeLine(int index);
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/TextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/TextHologram.java
@@ -7,7 +7,7 @@ import java.util.List;
  */
 public interface TextHologram extends Hologram {
     /**
-     * @return mutable list of lines of text.
+     * @return immutable list of lines of text.
      */
     List<String> getLines();
 

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/AbstractHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/AbstractHologram.java
@@ -1,0 +1,77 @@
+package gg.nextforge.textblockitemdisplay.impl;
+
+import gg.nextforge.textblockitemdisplay.Hologram;
+import org.bukkit.Location;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Base implementation for holograms providing thread-safe updates.
+ */
+public abstract class AbstractHologram implements Hologram {
+    protected final String name;
+    protected Location location;
+    private boolean spawned;
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    protected AbstractHologram(String name, Location location) {
+        this.name = name;
+        this.location = location.clone();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Location getLocation() {
+        lock.readLock().lock();
+        try {
+            return location.clone();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void setLocation(Location location) {
+        lock.writeLock().lock();
+        try {
+            this.location = location.clone();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void spawn() {
+        lock.writeLock().lock();
+        try {
+            this.spawned = true;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void despawn() {
+        lock.writeLock().lock();
+        try {
+            this.spawned = false;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean isSpawned() {
+        lock.readLock().lock();
+        try {
+            return spawned;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleBlockHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleBlockHologram.java
@@ -1,0 +1,27 @@
+package gg.nextforge.textblockitemdisplay.impl;
+
+import gg.nextforge.textblockitemdisplay.BlockHologram;
+import org.bukkit.Location;
+import org.bukkit.Material;
+
+/**
+ * Basic implementation of a block hologram.
+ */
+public class SimpleBlockHologram extends AbstractHologram implements BlockHologram {
+    private Material material;
+
+    public SimpleBlockHologram(String name, Location location, Material material) {
+        super(name, location);
+        this.material = material;
+    }
+
+    @Override
+    public Material getBlockType() {
+        return material;
+    }
+
+    @Override
+    public void setBlockType(Material material) {
+        this.material = material;
+    }
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleItemHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleItemHologram.java
@@ -1,0 +1,27 @@
+package gg.nextforge.textblockitemdisplay.impl;
+
+import gg.nextforge.textblockitemdisplay.ItemHologram;
+import org.bukkit.Location;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Basic implementation of an item hologram.
+ */
+public class SimpleItemHologram extends AbstractHologram implements ItemHologram {
+    private ItemStack item;
+
+    public SimpleItemHologram(String name, Location location, ItemStack item) {
+        super(name, location);
+        this.item = item.clone();
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public void setItem(ItemStack item) {
+        this.item = item.clone();
+    }
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
@@ -19,7 +19,9 @@ public class SimpleTextHologram extends AbstractHologram implements TextHologram
 
     @Override
     public List<String> getLines() {
-        return Collections.unmodifiableList(new ArrayList<>(lines));
+        synchronized (lines) {
+            return Collections.unmodifiableList(new ArrayList<>(lines));
+        }
     }
 
     @Override

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
@@ -19,7 +19,7 @@ public class SimpleTextHologram extends AbstractHologram implements TextHologram
 
     @Override
     public List<String> getLines() {
-        return lines;
+        return Collections.unmodifiableList(new ArrayList<>(lines));
     }
 
     @Override

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
@@ -37,6 +37,9 @@ public class SimpleTextHologram extends AbstractHologram implements TextHologram
 
     @Override
     public void removeLine(int index) {
+        if (index < 0 || index >= lines.size()) {
+            throw new IllegalArgumentException("Index out of bounds: " + index + ". Valid range: 0 to " + (lines.size() - 1));
+        }
         lines.remove(index);
     }
 }

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
@@ -24,6 +24,9 @@ public class SimpleTextHologram extends AbstractHologram implements TextHologram
 
     @Override
     public void setLine(int index, String text) {
+        if (index < 0 || index >= lines.size()) {
+            throw new IllegalArgumentException("Index out of bounds: " + index + ". Valid range is [0, " + (lines.size() - 1) + "].");
+        }
         lines.set(index, text);
     }
 

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
@@ -1,0 +1,39 @@
+package gg.nextforge.textblockitemdisplay.impl;
+
+import gg.nextforge.textblockitemdisplay.TextHologram;
+import org.bukkit.Location;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Basic implementation of a text hologram.
+ */
+public class SimpleTextHologram extends AbstractHologram implements TextHologram {
+    private final List<String> lines = Collections.synchronizedList(new ArrayList<>());
+
+    public SimpleTextHologram(String name, Location location) {
+        super(name, location);
+    }
+
+    @Override
+    public List<String> getLines() {
+        return lines;
+    }
+
+    @Override
+    public void setLine(int index, String text) {
+        lines.set(index, text);
+    }
+
+    @Override
+    public void addLine(String text) {
+        lines.add(text);
+    }
+
+    @Override
+    public void removeLine(int index) {
+        lines.remove(index);
+    }
+}

--- a/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
+++ b/src/main/java/gg/nextforge/textblockitemdisplay/impl/SimpleTextHologram.java
@@ -40,7 +40,7 @@ public class SimpleTextHologram extends AbstractHologram implements TextHologram
     @Override
     public void removeLine(int index) {
         if (index < 0 || index >= lines.size()) {
-            throw new IllegalArgumentException("Index out of bounds: " + index + ". Valid range: 0 to " + (lines.size() - 1));
+            throw new IllegalArgumentException("Index out of bounds: " + index + ". Valid range is [0, " + (lines.size() - 1) + "].");
         }
         lines.remove(index);
     }

--- a/src/test/java/gg/nextforge/textblockitemdisplay/HologramManagerTest.java
+++ b/src/test/java/gg/nextforge/textblockitemdisplay/HologramManagerTest.java
@@ -1,0 +1,43 @@
+package gg.nextforge.textblockitemdisplay;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link HologramManager}.
+ */
+public class HologramManagerTest {
+
+    private HologramManager manager;
+    private World world;
+
+    @BeforeEach
+    void setUp() {
+        manager = new HologramManager();
+        world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+    }
+
+    @Test
+    void createTextHologram() {
+        Location loc = new Location(world, 0, 0, 0);
+        TextHologram holo = manager.createTextHologram("test", loc);
+        assertNotNull(holo);
+        assertEquals(holo, manager.get("test"));
+    }
+
+    @Test
+    void copyItemHologram() {
+        Location loc = new Location(world, 1, 2, 3);
+        ItemHologram ih = manager.createItemHologram("i", loc, new ItemStack(Material.STONE));
+        manager.createItemHologram("copy", ih.getLocation(), ih.getItem());
+        assertEquals(2, manager.getHolograms().size());
+    }
+}


### PR DESCRIPTION
## Summary
- add simple hologram API with text, item and block variants
- add basic command `/hologram` to manage holograms
- expose hologram manager in `NextForgePlugin`
- hook hologram command into `NextCorePlugin`
- add unit test for the manager
- enable JUnit tests in `build.gradle`

## Testing
- `./gradlew test --no-daemon` *(fails: cannot find Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6870dc940db8832cb1d26bfe4d81c4c0